### PR TITLE
Share one project list; show only blog posts on /posts/

### DIFF
--- a/data/en/sideprojects.yaml
+++ b/data/en/sideprojects.yaml
@@ -1,0 +1,29 @@
+# Side-project cards — single source of truth shared by:
+#   - the homepage "Other projects" section (layouts/index.html)
+#   - the /projects/ page (layouts/projects/list.html)
+# Add a project here once and it shows up in both places.
+#
+# Fields:
+#   name     — project name
+#   url      — link target
+#   urlLabel — short display label for the link (no scheme)
+#   tagline  — one-line summary (shown on both the homepage card and /projects/)
+#   desc     — longer description (shown only on the /projects/ page; optional)
+
+- name: Travels
+  url: https://travel.mariatta.ca
+  urlLabel: travel.mariatta.ca
+  tagline: Travel planning without spreadsheets.
+  desc: A field log of trips, places, and the meals worth remembering.
+
+- name: Secret Codes
+  url: https://secretcodes.dev
+  urlLabel: secretcodes.dev
+  tagline: Small, useful automations. Runs without third-party trackers or cookie gauntlets.
+  desc: Where I keep the small tools I've built for myself.
+
+- name: Hot Lunch Handbook
+  url: https://mariatta.ca/lunch-handbook/
+  urlLabel: mariatta.ca/lunch-handbook
+  tagline: An open handbook for the parent volunteers who run school hot lunch.
+  desc: Everything I learned running my kids' school hot lunch program, documented openly for whoever runs it next.

--- a/data/en/sideprojects.yaml
+++ b/data/en/sideprojects.yaml
@@ -1,29 +1,70 @@
-# Side-project cards — single source of truth shared by:
-#   - the homepage "Other projects" section (layouts/index.html)
-#   - the /projects/ page (layouts/projects/list.html)
-# Add a project here once and it shows up in both places.
+# Shared project data — single source of truth for:
+#   - the homepage "Other projects" section (layouts/index.html), shown flat
+#   - the /projects/ page (layouts/projects/list.html), shown as labeled groups
+# Add a project under the right group once and it appears in both places.
 #
-# Fields:
+# Per-project fields:
 #   name     — project name
 #   url      — link target
 #   urlLabel — short display label for the link (no scheme)
-#   tagline  — one-line summary (shown on both the homepage card and /projects/)
-#   desc     — longer description (shown only on the /projects/ page; optional)
+#   role     — your role (optional; e.g. "Co-maintainer"). Shown on /projects/.
+#   tagline  — one-line summary (homepage card + /projects/)
+#   desc     — longer description (only on /projects/; optional)
 
-- name: Travels
-  url: https://travel.mariatta.ca
-  urlLabel: travel.mariatta.ca
-  tagline: Travel planning without spreadsheets.
-  desc: A field log of trips, places, and the meals worth remembering.
+groups:
+  - title: Things I build
+    projects:
+      - name: Travels
+        url: https://travel.mariatta.ca
+        urlLabel: travel.mariatta.ca
+        tagline: Travel planning without spreadsheets.
+        desc: A field log of trips, places, and the meals worth remembering.
 
-- name: Secret Codes
-  url: https://secretcodes.dev
-  urlLabel: secretcodes.dev
-  tagline: Small, useful automations. Runs without third-party trackers or cookie gauntlets.
-  desc: Where I keep the small tools I've built for myself.
+      - name: Secret Codes
+        url: https://secretcodes.dev
+        urlLabel: secretcodes.dev
+        tagline: Small, useful automations. Runs without third-party trackers or cookie gauntlets.
+        desc: Where I keep the small tools I've built for myself.
 
-- name: Hot Lunch Handbook
-  url: https://mariatta.ca/lunch-handbook/
-  urlLabel: mariatta.ca/lunch-handbook
-  tagline: An open handbook for the parent volunteers who run school hot lunch.
-  desc: Everything I learned running my kids' school hot lunch program, documented openly for whoever runs it next.
+      - name: Hot Lunch Handbook
+        url: https://mariatta.ca/lunch-handbook/
+        urlLabel: mariatta.ca/lunch-handbook
+        tagline: An open handbook for the parent volunteers who run school hot lunch.
+        desc: Everything I learned running my kids' school hot lunch program, documented openly for whoever runs it next.
+
+  - title: Things I help maintain
+    projects:
+      - name: gidgethub
+        url: https://gidgethub.readthedocs.io
+        urlLabel: gidgethub.readthedocs.io
+        role: Co-maintainer
+        tagline: An async GitHub API library for Python.
+        desc: A small async wrapper around the GitHub API — the library behind the bots that help keep CPython's pull requests moving.
+
+      - name: Python Docs Editorial Board
+        url: https://python.github.io/editorial-board/
+        urlLabel: python.github.io/editorial-board
+        role: Board member
+        tagline: Stewarding the contribution process for Python's official documentation.
+        desc: The board that supports and guides documentation contributors across the CPython project.
+
+      - name: PyCon Maintainers Summit
+        url: https://pycon-maintainers-summit.github.io/
+        urlLabel: pycon-maintainers-summit.github.io
+        role: Co-organizer
+        tagline: A gathering for open source maintainers at PyCon US.
+        desc: A space at PyCon US for the people who keep open source projects running to share what they've learned and support one another.
+
+      - name: PyLadiesCon
+        url: https://conference.pyladies.com
+        urlLabel: conference.pyladies.com
+        role: Core organizer
+        tagline: A free, global, online conference by and for the PyLadies community.
+        desc: An annual online conference celebrating PyLadies and women in the Python community around the world.
+
+      - name: PyLadiesCon Portal
+        url: https://portal.pyladies.com
+        urlLabel: portal.pyladies.com
+        role: Co-maintainer
+        tagline: The open source platform that powers PyLadiesCon.
+        desc: A web app for running PyLadiesCon — handling sign-ups, volunteers, and the coordination behind the conference.

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -37,28 +37,13 @@
     <section class="home-projects" aria-labelledby="home-projects-heading">
       <p class="home-section-label" id="home-projects-heading">Other projects</p>
       <div class="projects">
-        <a class="project" href="https://travel.mariatta.ca">
-          <div class="project-name">Travels</div>
-          <div class="project-url">travel.mariatta.ca &rarr;</div>
-          <div class="project-desc">Travel planning without spreadsheets.</div>
+        {{- range (index site.Data site.Language.Lang "sideprojects") }}
+        <a class="project" href="{{ .url }}">
+          <div class="project-name">{{ .name }}</div>
+          <div class="project-url">{{ .urlLabel }} &rarr;</div>
+          <div class="project-desc">{{ .tagline }}</div>
         </a>
-        <a class="project" href="https://secretcodes.dev">
-          <div class="project-name">Secret Codes</div>
-          <div class="project-url">secretcodes.dev &rarr;</div>
-          <div class="project-desc">Small, useful automations. Runs without third-party trackers or cookie gauntlets.</div>
-        </a>
-        <a class="project" href="https://mariatta.ca/lunch-handbook/">
-          <div class="project-name">Hot Lunch Handbook</div>
-          <div class="project-url">mariatta.ca/lunch-handbook &rarr;</div>
-          <div class="project-desc">An open handbook for the parent volunteers who run school hot lunch.</div>
-        </a>
-        {{/* Hidden until nospreadsheet.dev is live.
-        <a class="project" href="https://nospreadsheet.dev">
-          <div class="project-name">No Spreadsheet</div>
-          <div class="project-url">nospreadsheet.dev &rarr;</div>
-          <div class="project-desc">Tools for people who'd rather not open another sheet today.</div>
-        </a>
-        */}}
+        {{- end }}
       </div>
     </section>
 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -37,12 +37,14 @@
     <section class="home-projects" aria-labelledby="home-projects-heading">
       <p class="home-section-label" id="home-projects-heading">Other projects</p>
       <div class="projects">
-        {{- range (index site.Data site.Language.Lang "sideprojects") }}
+        {{- range (index site.Data site.Language.Lang "sideprojects").groups }}
+        {{- range .projects }}
         <a class="project" href="{{ .url }}">
           <div class="project-name">{{ .name }}</div>
           <div class="project-url">{{ .urlLabel }} &rarr;</div>
           <div class="project-desc">{{ .tagline }}</div>
         </a>
+        {{- end }}
         {{- end }}
       </div>
     </section>

--- a/layouts/posts/list.html
+++ b/layouts/posts/list.html
@@ -20,6 +20,19 @@
     </header>
 
     {{ $pages := .RegularPagesRecursive.ByDate.Reverse }}
+    {{/* On the top-level /posts/ page, hide sub-sections that have their own pages
+         (talks, ice cream selfies, typo of the day, speaker bio). */}}
+    {{ if eq .RelPermalink "/posts/" }}
+      {{ $excludes := slice "posts/talks" "posts/ice_cream_selfies" "posts/typo_of_the_day" "posts/speaker_bio" }}
+      {{ $blog := slice }}
+      {{ range $pages }}
+        {{ $dir := path.Dir .File.Path }}
+        {{ $skip := false }}
+        {{ range $excludes }}{{ if hasPrefix $dir . }}{{ $skip = true }}{{ end }}{{ end }}
+        {{ if not $skip }}{{ $blog = $blog | append . }}{{ end }}
+      {{ end }}
+      {{ $pages = $blog }}
+    {{ end }}
     {{ if $pages }}
       {{ if .Params.archive }}
         {{ $byYear := $pages.GroupByDate "2006" }}

--- a/layouts/projects/list.html
+++ b/layouts/projects/list.html
@@ -8,24 +8,28 @@
 
     <header class="page-header">
       <p class="page-eyebrow">Projects</p>
-      <h1 class="page-title">Side projects, small tools, and other things I&rsquo;m building outside of work.</h1>
-      <p class="page-intro">Each project below has its own home — these cards are a quick tour. They&rsquo;re different in tone and topic, but they share a common thread: scratching my own itch.</p>
+      <h1 class="page-title">Things I build, and things I help keep running.</h1>
+      <p class="page-intro">A mix of small tools I&rsquo;ve made to scratch my own itch, and open source and community projects I help maintain. Each one has its own home &mdash; these cards are a quick tour.</p>
     </header>
 
+    {{- range (index site.Data site.Language.Lang "sideprojects").groups }}
+    <h2 class="project-group-title">{{ .title }}</h2>
     <ul class="project-list">
-      {{- range (index site.Data site.Language.Lang "sideprojects") }}
+      {{- range .projects }}
       <li class="project-detail">
         <a class="project-detail-card" href="{{ .url }}">
           <div class="project-detail-head">
             <p class="project-detail-name">{{ .name }}</p>
             <p class="project-detail-url">{{ .urlLabel }} &rarr;</p>
           </div>
+          {{- with .role }}<p class="project-detail-role">{{ . }}</p>{{- end }}
           <p class="project-detail-tagline">{{ .tagline }}</p>
           {{- with .desc }}<p class="project-detail-desc">{{ . }}</p>{{- end }}
         </a>
       </li>
       {{- end }}
     </ul>
+    {{- end }}
 
     <p class="page-back"><a href="{{ "/" | relLangURL }}">&larr; Back home</a></p>
   </div>
@@ -67,6 +71,23 @@
     color: var(--c-muted);
     max-width: 56ch;
     margin: 0;
+  }
+
+  .project-group-title {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--c-muted);
+    margin: 44px 0 16px;
+  }
+  .project-group-title:first-of-type { margin-top: 0; }
+  .project-detail-role {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.04em;
+    color: var(--c-rose);
+    margin: 0 0 8px;
   }
 
   .project-list {

--- a/layouts/projects/list.html
+++ b/layouts/projects/list.html
@@ -13,47 +13,18 @@
     </header>
 
     <ul class="project-list">
-
+      {{- range (index site.Data site.Language.Lang "sideprojects") }}
       <li class="project-detail">
-        <a class="project-detail-card" href="https://travel.mariatta.ca">
+        <a class="project-detail-card" href="{{ .url }}">
           <div class="project-detail-head">
-            <p class="project-detail-name">Travels</p>
-            <p class="project-detail-url">travel.mariatta.ca &rarr;</p>
+            <p class="project-detail-name">{{ .name }}</p>
+            <p class="project-detail-url">{{ .urlLabel }} &rarr;</p>
           </div>
-          <p class="project-detail-tagline">Travel planning without spreadsheets.</p>
-          <p class="project-detail-desc">A field log of trips, places, and the meals worth remembering.</p>
-
+          <p class="project-detail-tagline">{{ .tagline }}</p>
+          {{- with .desc }}<p class="project-detail-desc">{{ . }}</p>{{- end }}
         </a>
       </li>
-
-      <li class="project-detail">
-        <a class="project-detail-card" href="https://secretcodes.dev">
-          <div class="project-detail-head">
-            <p class="project-detail-name">Secret Codes</p>
-            <p class="project-detail-url">secretcodes.dev &rarr;</p>
-          </div>
-          <p class="project-detail-tagline">Small, useful automations. Runs without third-party trackers or cookie gauntlets.</p>
-          <p class="project-detail-desc">
-
-            Where I keep the small tools I've built for myself.
-
-          </p>
-
-        </a>
-      </li>
-
-      {{/* Hidden until nospreadsheet.dev is live.
-      <li class="project-detail">
-        <a class="project-detail-card" href="https://nospreadsheet.dev">
-          <div class="project-detail-name-only">No Spreadsheet</div>
-          <p class="project-detail-tagline">Tools for people who&rsquo;d rather not open another sheet today.</p>
-          <p class="project-detail-desc">A small home for tiny utilities that replace spreadsheet workflows I kept finding myself in. Built one tool at a time, when the spreadsheet finally annoys me enough.</p>
-          <p class="project-detail-url">nospreadsheet.dev &rarr;</p>
-
-        </a>
-      </li>
-      */}}
-
+      {{- end }}
     </ul>
 
     <p class="page-back"><a href="{{ "/" | relLangURL }}">&larr; Back home</a></p>


### PR DESCRIPTION
Two related maintenance changes.

**1. One shared, grouped project list.** The homepage "Other projects" section and the `/projects/` page were two separate hardcoded lists, so adding a project (the Hot Lunch Handbook) only updated one of them. Both now render from a single source of truth: `data/en/sideprojects.yaml`, organized into two groups:

- **Things I build** — Travels, Secret Codes, Hot Lunch Handbook
- **Things I help maintain** — gidgethub, Python Docs Editorial Board, PyCon Maintainers Summit, PyLadiesCon, PyLadiesCon Portal (each with a role label)

The `/projects/` page shows the groups with headings; the homepage "Other projects" shows them flat. Add or edit a project in the data file once and it updates both places.

**2. `/posts/` shows only blog posts.** The top-level `/posts/` listing pulled in `.RegularPagesRecursive`, which mixed in the self-contained sub-sections (`talks`, `ice_cream_selfies`, `typo_of_the_day`, `speaker_bio`). Those are now filtered out on the `/posts/` page only; their own section pages are unaffected.
