### PR TITLE
Remove Disqus comments and Google Analytics

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -13,6 +13,23 @@ taxonomies:
 languageCode: en-us
 title: "Mariatta"
 
+# Privacy hardening: no third-party cookies from Hugo's built-in embeds.
+# YouTube embeds are served from youtube-nocookie.com; Disqus and
+# Google Analytics internal templates are hard-disabled as a backstop.
+privacy:
+  disqus:
+    disable: true
+  googleAnalytics:
+    disable: true
+  youTube:
+    privacyEnhanced: true
+  x:
+    enableDNT: true
+  vimeo:
+    enableDNT: true
+  instagram:
+    simple: true
+
 # Use Hugo modules to add theme
 module:
   imports:
@@ -117,20 +134,13 @@ params:
     notes:
       enable: false
 
-    # Enable comment feature. There, should be only one of them.
+    # Comments are disabled (Disqus removed to avoid third-party cookies).
     comment:
-      enable: true
-      services:
-        disqus:
-          shortName: mariatta
+      enable: false
 
-    # Enable Analytics
+    # Analytics disabled (Google Analytics sets cookies).
     analytics:
-      enabled: true
-      services:
-        # Google Analytics
-        google:
-          id: G-1T2VT3L88K
+      enabled: false
 
     # Enable Support
     support:


### PR DESCRIPTION
## Summary

Removes all tracking-cookie sources from the site:

- **Disqus comments removed**: `features.comment` is disabled and the Disqus shortname config is deleted, so the comments section no longer renders on posts.
- **Google Analytics removed**: `features.analytics` is disabled (GA sets `_ga` cookies on every page).
- **Hugo privacy settings added**: hard-disables the Disqus and Google Analytics internal templates as a backstop, serves all `{{< youtube >}}` embeds from `youtube-nocookie.com` (22 embeds), and enables Do Not Track mode for X and Vimeo embeds.

## Verification

Clean `hugo --gc --minify` build: zero references to Disqus, gtag, or googletagmanager in any generated HTML, and all YouTube iframes point to `youtube-nocookie.com`.

Remaining third-party embeds (Google Maps iframes in ice cream selfie posts, a few Facebook and Spotify embeds in old posts) can still set cookies on the specific pages that contain them; those are raw HTML in content files and out of scope here.