### PR TITLE
Add Popular theme to projects

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -34,6 +34,7 @@ privacy:
 module:
   imports:
   - path: github.com/hugo-toha/toha/v4
+  - path: github.com/mfg92/hugo-shortcode-gallery
   mounts:
   - source: static/files
     target: static/files

--- a/data/en/sideprojects.yaml
+++ b/data/en/sideprojects.yaml
@@ -26,6 +26,12 @@ groups:
         tagline: Small, useful automations. Runs without third-party trackers or cookie gauntlets.
         desc: Where I keep the small tools I've built for myself.
 
+      - name: Popular
+        url: https://mariatta.ca/hugo-theme-popular
+        urlLabel: mariatta.ca/hugo-theme-popular
+        tagline: A warm, community-first Hugo theme for meetups, clubs and fan communities.
+        desc: Named after the Darren Hayes song. Events, speakers, venues, runbooks, and a blog out of the box, with an Astro twin (astro-theme-popular).
+
       - name: Hot Lunch Handbook
         url: https://mariatta.ca/lunch-handbook/
         urlLabel: mariatta.ca/lunch-handbook

--- a/data/en/sideprojects.yaml
+++ b/data/en/sideprojects.yaml
@@ -29,8 +29,8 @@ groups:
       - name: Popular
         url: https://mariatta.ca/hugo-theme-popular
         urlLabel: mariatta.ca/hugo-theme-popular
-        tagline: A warm, community-first Hugo theme for meetups, clubs and fan communities.
-        desc: Named after the Darren Hayes song. Events, speakers, venues, runbooks, and a blog out of the box, with an Astro twin (astro-theme-popular).
+        tagline: A warm, community-first theme for meetups, clubs and fan communities, available for both Hugo and Astro.
+        desc: Named after the Darren Hayes song. Twin themes (hugo-theme-popular and astro-theme-popular) kept in lockstep by a parity contract, with events, speakers, venues, runbooks, and a blog out of the box.
 
       - name: Hot Lunch Handbook
         url: https://mariatta.ca/lunch-handbook/

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,10 @@ go 1.21
 
 toolchain go1.21.6
 
-require github.com/hugo-toha/toha/v4 v4.13.0 // indirect
+require (
+	github.com/hugo-toha/toha/v4 v4.13.0 // indirect
+	github.com/mfg92/hugo-shortcode-gallery v1.4.0 // indirect
+)
 
 // replace(
 //     github.com/hugo-toha/toha/v4 => ../toha

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
 github.com/hugo-toha/toha/v4 v4.13.0 h1:h6ZKpqSZIcNK8ufptcRbg+Bm63tBq7v+X2jCC1mlcwg=
 github.com/hugo-toha/toha/v4 v4.13.0/go.mod h1:TU/6WXz7fJ3BSrTS+K/sVctzUMF4pB4ZwKWzFBFra8g=
+github.com/mfg92/hugo-shortcode-gallery v1.4.0 h1:QS6L448HSnMSJwnH4HY+euTemuK1Dsq6lfYIRU8cLV4=
+github.com/mfg92/hugo-shortcode-gallery v1.4.0/go.mod h1:SEdbeBGSMX2lP+4nCqqy9AyTWWktUMWXYnR3r1l01Rw=


### PR DESCRIPTION
## Summary

- Add **Popular** to the projects list under "Things I build". Popular is a warm, community-first theme for meetups, clubs and fan communities, shipped as twin themes (hugo-theme-popular and astro-theme-popular) kept in lockstep by a parity contract. Links to the project site at mariatta.ca/hugo-theme-popular, which documents both variants.
- Add the `hugo-shortcode-gallery` Hugo module (config.yaml, go.mod, go.sum) for upcoming posts that use photo galleries. Ran `hugo mod tidy`, which also cleaned stray toha v4.15.0 hashes from go.sum.

## Verification

Clean `hugo --gc --minify` build: the Popular entry renders on both the homepage "Other projects" section and the /projects/ page.