### PR TITLE
Mention the MVP in the About page description, and emit a meta description

### DIFF
--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -1,4 +1,6 @@
 ---
 title: "About"
-description: "Open source maintainer, Python core developer, conference organizer, community builder."
+description:
+  "Multi-award winning open source maintainer, Python core developer, Microsoft MVP, conference organizer, community
+  builder."
 ---

--- a/layouts/about/list.html
+++ b/layouts/about/list.html
@@ -1,3 +1,7 @@
+{{ define "header" }}
+<meta name="description" content="{{ .Description | default .Title }}" />
+{{ end }}
+
 {{ define "navbar" }}
   {{ partial "navigators/navbar.html" . }}
 {{ end }}


### PR DESCRIPTION
Follow-up to #25.

## The description

`/about/` described you as "Open source maintainer, Python core developer, conference organizer,
community builder." Now:

> Multi-award winning open source maintainer, Python core developer, Microsoft MVP, conference
> organizer, community builder.

This brings the page's meta description in line with its own summary and the author role list,
both updated in #25.

## The bug I found while doing it

That description was only reaching `og:description` and `twitter:description`. `/about/` emitted no
`<meta name="description">` at all, so the text search engines actually read was missing entirely.

`layouts/about/list.html` defines no `header` block. `layouts/_default/single.html` does, which is
why individual posts have a meta description and the custom list pages don't. Added one to the
About layout, matching the pattern already in `single.html`.

**The same gap exists on `/` and `/projects/`**, which also render through custom list layouts.
Not fixed here, since neither is about the MVP credentials. Happy to do them in a separate PR.

## Not included

The homepage intro still reads "Notes from a Python core developer, community builder, and serial
conference organizer", left as is on request. It is written as notes-from-a-person rather than a
credential list, and a CV line sits differently in that voice.
